### PR TITLE
Improve NIST NVD API key import

### DIFF
--- a/CveXplore/core/nvd_nist/nvd_nist_api.py
+++ b/CveXplore/core/nvd_nist/nvd_nist_api.py
@@ -55,7 +55,8 @@ class NvdNistApi(ApiBaseClass, UpdateBaseClass):
             self.api_key_limit = False
         else:
             self.logger.warning(
-                "Could not find a NIST API Key in the '~/.cvexplore/.env' file; "
+                "Could not find a NIST API Key in the environment variable 'NVD_NIST_API_KEY' "
+                "(e.g. from the '~/.cvexplore/.env' file); "
                 "you could request one at: https://nvd.nist.gov/developers/request-an-api-key"
             )
             self.api_key_limit = True

--- a/CveXplore/main.py
+++ b/CveXplore/main.py
@@ -14,7 +14,7 @@ user_wd = os.path.expanduser("~/.cvexplore")
 
 if not os.path.exists(os.path.join(user_wd, ".env")):
     shutil.copyfile(
-        os.path.join(os.path.dirname(__file__), ".env_example"),
+        os.path.join(os.path.dirname(__file__), "common/.env_example"),
         os.path.join(user_wd, ".env"),
     )
 
@@ -22,7 +22,7 @@ load_dotenv(os.path.join(user_wd, ".env"))
 
 if not os.path.exists(os.path.join(user_wd, ".sources.ini")):
     shutil.copyfile(
-        os.path.join(os.path.dirname(__file__), ".sources.ini"),
+        os.path.join(os.path.dirname(__file__), "common/.sources.ini"),
         os.path.join(user_wd, ".sources.ini"),
     )
 


### PR DESCRIPTION
## Better warning message for a missing NIST API key

The current error message does not explain that the API key should be in the environment variable `NVD_NIST_API_KEY`. The `~/.cvexplore/.env` file mentioned is only a single option to set the variable, and even in that case one should know the name of the variable.

E.g. when using CVE-Search as a SystemD `DynamicUser` service it does not even have a home directory. As CveXplore is currently written, it expects it was run as/by a static user. This could be circumvented using a state directory. However, a state directory is not a suitable place for such configuration. Instead, it could be given to the service by SystemD. E.g.

```
[Service]
User=cve
DynamicUser=yes
StateDirectory=cve
Environment=HOME=/var/lib/cve
Environment=NVD_NIST_API_KEY=abbaacdc-abba-acdc-abba-acdcabbaacdc
```

Or, to keep it secret, as an `EnvironmentFile` that only `root` as read access to:

```
[Service]
EnvironmentFile=/etc/cvesearch/nist-api-key.env
```

This documentation change makes the error more generic for all kinds of deployments.

## Fix default configuration file paths

The files are not in the same directory as main.py but in the `common/` subdirectory.