### PR TITLE
Upgrade workflow actions

### DIFF
--- a/.github/workflows/auto_docs.yaml
+++ b/.github/workflows/auto_docs.yaml
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.10'
       - name: Cache pip
         id: cache-dev-pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           # path: ~/.cache/pip

--- a/.github/workflows/auto_docs.yaml
+++ b/.github/workflows/auto_docs.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up Python 3.10

--- a/.github/workflows/auto_docs.yaml
+++ b/.github/workflows/auto_docs.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Cache pip

--- a/.github/workflows/bandit-sec-checks.yaml
+++ b/.github/workflows/bandit-sec-checks.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Python ${{ matrix.python-version }} ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Security check - Bandit
       uses: Joel-hanson/bandit-report-artifacts@V1

--- a/.github/workflows/bandit-sec-checks.yaml
+++ b/.github/workflows/bandit-sec-checks.yaml
@@ -24,7 +24,7 @@ jobs:
         ignore_failure: true
 
     - name: Security check report artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       # if: failure()
       with:
         name: Security report

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,7 +12,7 @@ jobs:
     name: Black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check Black formatting for Python scripts
         uses: psf/black@stable
         with:

--- a/.github/workflows/package_to_pypi.yaml
+++ b/.github/workflows/package_to_pypi.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Commits to file
@@ -35,7 +35,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/package_to_pypi.yaml
+++ b/.github/workflows/package_to_pypi.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install dependencies


### PR DESCRIPTION
 - Node.js 16 actions are deprecated and actions running on Node.js older than that are forced to run on Node.js 16.
 - Also `actions/upload-artifact` had more recent versions; actually v4 would be the latest major version.