### PR TITLE
Compare CWE, CAPEC & VIA4 last-modified using HEAD

### DIFF
--- a/CveXplore/core/database_maintenance/download_handler.py
+++ b/CveXplore/core/database_maintenance/download_handler.py
@@ -307,7 +307,7 @@ class DownloadHandler(ABC):
 
             if i is None:
                 self.logger.info(
-                    f"Cached last-modified for {self.feed_type}'s not found; update"
+                    f"Cached last-modified for {self.feed_type}'s not found; should update"
                 )
                 return True
             else:
@@ -333,12 +333,12 @@ class DownloadHandler(ABC):
 
                         if self.last_modified == i["lastModified"]:
                             self.logger.info(
-                                f"{self.feed_type}'s are not modified since the last update; skipping update"
+                                f"{self.feed_type}'s are not modified since the last update"
                             )
                             return False
                         else:
                             self.logger.info(
-                                f"{self.feed_type}'s last-modified changed ({self.last_modified}); update"
+                                f"{self.feed_type}'s last-modified changed ({self.last_modified}); should update"
                             )
                             return True
 

--- a/CveXplore/core/database_maintenance/sources_process.py
+++ b/CveXplore/core/database_maintenance/sources_process.py
@@ -877,9 +877,11 @@ class VIADownloads(JSONFileHandler):
         if self.feed_type.lower() not in self.getTableNames():
             self.is_update = False
 
-        self.process_downloads([self.feed_url])
-
-        self.logger.info("Finished VIA4 database update")
+        if self.source_changed(self.feed_url):
+            self.process_downloads([self.feed_url])
+            self.logger.info("Finished VIA4 database update")
+        else:
+            self.logger.info("Skipped VIA4 database update")
 
         return self.last_modified
 
@@ -934,9 +936,11 @@ class CAPECDownloads(XMLFileHandler):
         if self.feed_type.lower() not in self.getTableNames():
             self.is_update = False
 
-        self.process_downloads([self.feed_url])
-
-        self.logger.info("Finished CAPEC database update")
+        if self.source_changed(self.feed_url):
+            self.process_downloads([self.feed_url])
+            self.logger.info("Finished CAPEC database update")
+        else:
+            self.logger.info("Skipped CAPEC database update")
 
         return self.last_modified
 
@@ -1000,9 +1004,11 @@ class CWEDownloads(XMLFileHandler):
         if self.feed_type.lower() not in self.getTableNames():
             self.is_update = False
 
-        self.process_downloads([self.feed_url])
-
-        self.logger.info("Finished CWE database update")
+        if self.source_changed(self.feed_url):
+            self.process_downloads([self.feed_url])
+            self.logger.info("Finished CWE database update")
+        else:
+            self.logger.info("Skipped CWE database update")
 
         return self.last_modified
 


### PR DESCRIPTION
Closes https://github.com/cve-search/CveXplore/issues/270

- New `source_changed()` uses the `last-modified` already cached in the `info` collection & compares it with the `last-modified` of the current source using HTTP HEAD method.
  - If those two are an exact match, return `False`; the update can be skipped.
  - In any other case including all exceptions assume the source has changed, return `True` and continue as before.
  - The `download_site()` already updates the cache so we don't have to worry about that here. The comparison of cached `last-modified` should now newer give "are not modified" for sources using `source_changed()`, but is still relevant for sources not using it.
- Use this method for CWE, CAPEC & VIA4 sources.
  - There's a valid reason documented as a comment in `download_site()` we should keep downloading EPSS.
