### PR TITLE
Fix mongo url with user/password

### DIFF
--- a/CveXplore/main.py
+++ b/CveXplore/main.py
@@ -144,7 +144,9 @@ class CveXplore(object):
         else:
             if self.datasource_type == "mongodb":
                 self._datasource_connection_details = {
-                    "host": f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}"
+                    "host": f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}" 
+                            if self.config.DATASOURCE_USER is None and self.config.DATASOURCE_PASSWORD is None
+                            else f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_USER}:{self.config.DATASOURCE_PASSWORD}@{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}" 
                 }
             elif self.datasource_type == "mysql":
                 self._datasource_connection_details = {

--- a/CveXplore/main.py
+++ b/CveXplore/main.py
@@ -145,8 +145,9 @@ class CveXplore(object):
             if self.datasource_type == "mongodb":
                 self._datasource_connection_details = {
                     "host": f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}" 
-                            if self.config.DATASOURCE_USER is None and self.config.DATASOURCE_PASSWORD is None
-                            else f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_USER}:{self.config.DATASOURCE_PASSWORD}@{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}" 
+                    if self.config.DATASOURCE_USER is None
+                    and self.config.DATASOURCE_PASSWORD is None
+                    else f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_USER}:{self.config.DATASOURCE_PASSWORD}@{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}"
                 }
             elif self.datasource_type == "mysql":
                 self._datasource_connection_details = {

--- a/CveXplore/main.py
+++ b/CveXplore/main.py
@@ -144,10 +144,12 @@ class CveXplore(object):
         else:
             if self.datasource_type == "mongodb":
                 self._datasource_connection_details = {
-                    "host": f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}" 
-                    if self.config.DATASOURCE_USER is None
-                    and self.config.DATASOURCE_PASSWORD is None
-                    else f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_USER}:{self.config.DATASOURCE_PASSWORD}@{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}"
+                    "host": (
+                        f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}"
+                        if self.config.DATASOURCE_USER is None
+                        and self.config.DATASOURCE_PASSWORD is None
+                        else f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_USER}:{self.config.DATASOURCE_PASSWORD}@{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}"
+                    )
                 }
             elif self.datasource_type == "mysql":
                 self._datasource_connection_details = {


### PR DESCRIPTION
Hi !

I'm currently migrating my instance of cve-search from version 4.x to version 5.x and CveExplorer does not allow connecting to a mongodb with a user and password.

I use the environment variables DATASOURCE_HOST, DATASOURCE_USER and DATASOURCE_PASSWORD but they are ignored for the connection to mongodb (only used for mysql)

The code would have to be adapted to take into account DATASOURCE_USER and DATASOURCE_PASSWORD also for the mongodb connection url. Or maybe use DATASOURCE_CONNECTION_DETAILS if defined as an environment variable.

THANKS