### PR TITLE
Defaults for DATASOURCE_USER & DATASOURCE_PASSWORD to None

### DIFF
--- a/CveXplore/common/config.py
+++ b/CveXplore/common/config.py
@@ -77,8 +77,8 @@ class Configuration(object):
         os.getenv("DATASOURCE_PORT", int(os.getenv("MONGODB_PORT", 27017)))
     )
 
-    DATASOURCE_USER = os.getenv("DATASOURCE_USER", "cvexplore")
-    DATASOURCE_PASSWORD = os.getenv("DATASOURCE_PASSWORD", "cvexplore")
+    DATASOURCE_USER = os.getenv("DATASOURCE_USER", None)
+    DATASOURCE_PASSWORD = os.getenv("DATASOURCE_PASSWORD", None)
     DATASOURCE_DBNAME = os.getenv("DATASOURCE_DBNAME", "cvexplore")
 
     DATASOURCE_CONNECTION_DETAILS = None


### PR DESCRIPTION
Fixes mongo url without user/password after #291.

### Cause

The #291 adds this if statement:

```
if self.config.DATASOURCE_USER is None
and self.config.DATASOURCE_PASSWORD is None
```

This condition is never met, because those variables have default values and it is impossible to explicitly set them to `None`, as `None` from an environment variable is treated as a string instead of [Python None Keyword](https://www.w3schools.com/python/ref_keyword_none.asp).

### Before

| `DATASOURCE_USER`  | `DATASOURCE_PASSWORD` | `self._datasource_connection_details` |
| :--- | :--- | :--- |
| (_unset_) | (_unset_)  | `{'host': 'mongodb://cvexplore:cvexplore@127.0.0.1:27017'}` |
| `None`  | `None`  | `{'host': 'mongodb://None:None@127.0.0.1:27017'}` |

### After

| `DATASOURCE_USER`  | `DATASOURCE_PASSWORD` | `self._datasource_connection_details` |
| :--- | :--- | :--- |
| (_unset_) | (_unset_)  |  `{'host': 'mongodb://127.0.0.1:27017'}` |
| `cvexplore`  | `password`  | `{'host': 'mongodb://cvexplore:password@127.0.0.1:27017'}` |