### PR TITLE
Pass DATASOURCE_DBNAME from Configuration() to MongoDBConnection()

### DIFF
--- a/CveXplore/database/connection/database_connection.py
+++ b/CveXplore/database/connection/database_connection.py
@@ -10,14 +10,14 @@ class DatabaseConnection(object):
         self.database_type = database_type
         self.database_init_parameters = database_init_parameters
 
-        self._database_connnections = {
+        self._database_connections = {
             "mongodb": MongoDBConnection,
             "api": ApiDatabaseSource,
             "mysql": SQLBaseConnection,
             "dummy": DummyConnection,
         }
 
-        self._database_connection = self._database_connnections[self.database_type](
+        self._database_connection = self._database_connections[self.database_type](
             **self.database_init_parameters
         )
 

--- a/CveXplore/main.py
+++ b/CveXplore/main.py
@@ -149,7 +149,8 @@ class CveXplore(object):
                         if self.config.DATASOURCE_USER is None
                         and self.config.DATASOURCE_PASSWORD is None
                         else f"{self.config.DATASOURCE_PROTOCOL}://{self.config.DATASOURCE_USER}:{self.config.DATASOURCE_PASSWORD}@{self.config.DATASOURCE_HOST}:{self.config.DATASOURCE_PORT}"
-                    )
+                    ),
+                    "database": self.config.DATASOURCE_DBNAME,
                 }
             elif self.datasource_type == "mysql":
                 self._datasource_connection_details = {


### PR DESCRIPTION
- [x] `MongoDBConnection()` always uses its default (`database: str = "cvedb"`)<br>unless the setting is passed via `_datasource_connection_details`.
- [x] Fix typo; `connnection` with three n's.
- [x] Test database init:
  - [x] should populate database with name from CVE-Search configuration
  - [x] CVE-Search should be able to use it.