### PR TITLE
Set update interval (1-120 days) manually for NVD API

### DIFF
--- a/CveXplore/core/database_maintenance/main_updater.py
+++ b/CveXplore/core/database_maintenance/main_updater.py
@@ -66,11 +66,11 @@ class MainUpdater(UpdateBaseClass):
 
         return True
 
-    def update(self, update_source: str | list = None):
+    def update(self, update_source: str | list = None, manual_days: int = 0):
         """
         Method used for updating the database
         """
-        self.logger.info(f"Starting Database update....")
+        self.logger.info(f"Starting Database update...")
         start_time = time.time()
 
         if not self.do_initialize:
@@ -88,7 +88,16 @@ class MainUpdater(UpdateBaseClass):
             if update_source is None:
                 for source in self.sources:
                     up = source["updater"]()
-                    up.update()
+                    if manual_days > 0:
+                        if source["name"] in ("cpe", "cve"):
+                            up.update(manual_days=manual_days)
+                        else:
+                            self.logger.warning(
+                                f"Update interval in days not supported by source {source}; ignoring"
+                            )
+                            up.update()
+                    else:
+                        up.update()
 
             elif isinstance(update_source, list):
                 for source in update_source:
@@ -97,7 +106,16 @@ class MainUpdater(UpdateBaseClass):
                             x for x in self.sources if x["name"] == source
                         ][0]
                         up = update_this_source["updater"]()
-                        up.update()
+                        if manual_days > 0:
+                            if update_this_source["name"] in ("cpe", "cve"):
+                                up.update(manual_days=manual_days)
+                            else:
+                                self.logger.warning(
+                                    f"Update interval in days not supported by source {source}; ignoring"
+                                )
+                                up.update()
+                        else:
+                            up.update()
                     except IndexError:
                         raise UpdateSourceNotFound(
                             f"Provided source: {source} could not be found...."
@@ -109,7 +127,16 @@ class MainUpdater(UpdateBaseClass):
                         x for x in self.sources if x["name"] == update_source
                     ][0]
                     up = update_this_source["updater"]()
-                    up.update()
+                    if manual_days > 0:
+                        if update_this_source["name"] in ("cpe", "cve"):
+                            up.update(manual_days=manual_days)
+                        else:
+                            self.logger.warning(
+                                f"Update interval in days not supported by source {source}; ignoring"
+                            )
+                            up.update()
+                    else:
+                        up.update()
                 except IndexError:
                     raise UpdateSourceNotFound(
                         f"Provided source: {update_source} could not be found...."

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,14 @@ You can add your `NIST API Key <https://nvd.nist.gov/developers/request-an-api-k
 :code:`NVD_NIST_API_KEY` (e.g., in the :code:`~/.cvexplore/.env` file). You can populate CveXplore without an API key,
 but it will limit the amount of parallel requests made to the NIST API.
 
+For the NVD API, the update starts from the last modified document in the database. In case of missing CPEs or CVEs
+caused by failures during the regular updates you can manually update entries for 1–120 days. (If the period is longer
+than 120 days you would need to re-populate the entire database.) Example:
+
+.. code-block:: python
+
+    >>> cvx.database.update(manual_days=7)
+
 Package usage
 -------------
 


### PR DESCRIPTION
Closes https://github.com/cve-search/CveXplore/issues/299

This takes 1-120 days before current date as an integer since it is easier to use than correctly formatted exact datetime. 

The NVD API supports downloading data for maximum 120 days. If the period missing CPEs or CVEs is longer than that, full re-population is required.

```
 - CveXplore.core.nvd_nist.nvd_nist_api - WARNING  - Requested timeframe exceeds the 120 days limit; capping the requested date range to 120 days. End date is now: 2020-08-29T15:40:27.088062
 - CveXplore.core.nvd_nist.nvd_nist_api - INFO     - Getting count for datasource: 2
 - CveXplore.core.nvd_nist.nvd_nist_api - INFO     - urllib3.util.retry did not support configurable backoff_max; falling back to default for urllib3 1.x compatibility
 - CveXplore.core.nvd_nist.nvd_nist_api - ERROR    - Unexpected response type: <Response [404]>
 - CveXplore.core.nvd_nist.nvd_nist_api - ERROR    - Data retrieval error: {'resultsPerPage': 1, 'lastModStartDate': '2020-04-30T15:45:01', 'lastModEndDate': '2020-08-29T15:40:27.088062'}
```

### Usage

```
>>> from CveXplore import CveXplore
>>> cvx = CveXplore()
>>> cvx.database.update(manual_days=7)
 - CveXplore.core.database_maintenance.main_updater - INFO     - Starting Database update...
 - CveXplore.core.nvd_nist.nvd_nist_api - WARNING  - Could not find a NIST API Key in the environment variable 'NVD_NIST_API_KEY' (e.g. from the '~/.cvexplore/.env' file); you could request one at: https://nvd.nist.gov/developers/request-an-api-key
 - CveXplore.core.database_maintenance.sources_process - INFO     - CPE database update started
 - CveXplore.core.database_maintenance.sources_process - INFO     - Starting download...
 - CveXplore.core.database_maintenance.sources_process - INFO     - Retrieving CPEs starting from 2024-06-25 18:59:04.364340
 - CveXplore.core.nvd_nist.nvd_nist_api - INFO     - Getting count for datasource: 2
 - CveXplore.core.nvd_nist.nvd_nist_api - INFO     - urllib3.util.retry did not support configurable backoff_max; falling back to default for urllib3 1.x compatibility
 - CveXplore.core.database_maintenance.sources_process - INFO     - Preparing to download 2031 CPE entries
```

Tested with variants:
- [x] `cvx.database.update("cpe", 1)`
- [x] `cvx.database.update("cve", 1)`
- [x] `cvx.database.update(None, 1)`
- [x] `cvx.database.update(manual_days=7)`
- [x] `cvx.database.update(["cve", "via4"], 1)`

The last one correctly gives:
```
 - CveXplore.core.database_maintenance.sources_process - INFO     - Retrieving CVEs starting from 2024-07-01 21:41:33.724703

 - CveXplore.core.database_maintenance.main_updater - WARNING  - Update interval in days not supported by source via4; ignoring
```