### PR TITLE
Windows compatibility for AppLogger & CWEDownloads

### DIFF
--- a/CveXplore/core/database_maintenance/sources_process.py
+++ b/CveXplore/core/database_maintenance/sources_process.py
@@ -997,22 +997,20 @@ class CWEDownloads(XMLFileHandler):
     def file_to_queue(self, file_tuple: Tuple[str, str]):
         working_dir, filename = file_tuple
 
-        for f in glob.glob(f"{working_dir}/*.xml"):
-            filename = f
+        for filename in glob.glob(f"{working_dir}/*.xml"):
+            self.parser.parse(filename)
+            x = 0
+            for cwe in self.ch.cwe:
+                try:
+                    cwe["related_weaknesses"] = list(set(cwe["related_weaknesses"]))
+                    cwe["description"] = cwe["Description"]
+                    cwe.pop("Description")
+                except KeyError:
+                    pass
+                self.process_item(cwe)
+                x += 1
 
-        self.parser.parse(f"file://{filename}")
-        x = 0
-        for cwe in self.ch.cwe:
-            try:
-                cwe["related_weaknesses"] = list(set(cwe["related_weaknesses"]))
-                cwe["description"] = cwe["Description"]
-                cwe.pop("Description")
-            except KeyError:
-                pass
-            self.process_item(cwe)
-            x += 1
-
-        self.logger.debug(f"Processed {x} entries from file: {filename}")
+            self.logger.debug(f"Processed {x} entries from file: {filename}")
 
         try:
             self.logger.debug(f"Removing working dir: {working_dir}")

--- a/CveXplore/core/logging/logger_class.py
+++ b/CveXplore/core/logging/logger_class.py
@@ -7,7 +7,6 @@ import colors
 from CveXplore.common.config import Configuration
 from CveXplore.core.logging.formatters.task_formatter import TaskFormatter
 from CveXplore.core.logging.handlers.gelf_handler import GelfUDPHandler
-from CveXplore.core.logging.handlers.syslog_handler import FullSysLogHandler
 
 CRITICAL = 50
 FATAL = CRITICAL
@@ -77,6 +76,11 @@ class AppLogger(logging.Logger):
                     ),
                 )
             else:
+                # Import syslog_handler only if configured (for Windows compatibility)
+                from CveXplore.core.logging.handlers.syslog_handler import (
+                    FullSysLogHandler,
+                )
+
                 syslog = FullSysLogHandler(
                     address=(syslog_server, syslog_port),
                     facility=FullSysLogHandler.LOG_LOCAL0,


### PR DESCRIPTION
- Import `FullSysLogHandler` from `CveXplore.core.logging.handlers.syslog_handler` only if configured. Ref. https://github.com/cve-search/cve-search/issues/143#issuecomment-2275723579
- Fix `urllib.error.URLError` in `class CWEDownloads`.