### PR TITLE
Extract NVD_NIST_TIMEOUT to settings

### DIFF
--- a/CveXplore/common/config.py
+++ b/CveXplore/common/config.py
@@ -122,6 +122,8 @@ class Configuration(object):
 
     NVD_NIST_API_KEY = os.getenv("NVD_NIST_API_KEY", None)
     NVD_NIST_NO_REJECTED = getenv_bool("NVD_NIST_NO_REJECTED", "True")
+    NVD_NIST_TIMEOUT = float(os.getenv("NVD_NIST_TIMEOUT", 30.0))
+
     HTTP_PROXY_DICT = getenv_dict("HTTP_PROXY_DICT", {})
     HTTP_PROXY_STRING = os.getenv("HTTP_PROXY_STRING", "")
 

--- a/CveXplore/core/nvd_nist/nvd_nist_api.py
+++ b/CveXplore/core/nvd_nist/nvd_nist_api.py
@@ -544,7 +544,10 @@ class ApiDataIterator(object):
                 loop=loop,
                 headers=self.api_data.api_handle.headers,
                 timeout=aiohttp.ClientTimeout(
-                    total=30.0, sock_connect=30.0, sock_read=30.0, connect=30.0
+                    total=self.config.NVD_NIST_TIMEOUT,
+                    sock_connect=self.config.NVD_NIST_TIMEOUT,
+                    sock_read=self.config.NVD_NIST_TIMEOUT,
+                    connect=self.config.NVD_NIST_TIMEOUT,
                 ),
             ) as session:
                 results = await asyncio.gather(

--- a/docs/general/settings.rst
+++ b/docs/general/settings.rst
@@ -42,6 +42,15 @@ NIST NVD API
 
    Do not import rejected CVEs from the NIST NVD API.
 
+.. confval:: NVD_NIST_TIMEOUT
+
+   Request timeout in seconds.
+
+   This value is used by aiohttp to set time limits for asynchronous requests to the NVD API,
+   including connection timeout and read timeout.
+
+   E.g., ``30.0``
+
 Downloads
 *********
 


### PR DESCRIPTION
- Moved the hardcoded timeout value (30.0) to a configurable setting `NVD_NIST_TIMEOUT`.
- Updated the aiohttp.ClientSession timeout settings to use `NVD_NIST_TIMEOUT` from environment variables.
- Added documentation for `NVD_NIST_TIMEOUT` in RST format.

This allows for easier configuration of timeout values without modifying the code.
fixes #307