### PR TITLE
Fix variable referenced before assignment

### DIFF
--- a/CveXplore/core/database_maintenance/download_handler.py
+++ b/CveXplore/core/database_maintenance/download_handler.py
@@ -255,6 +255,7 @@ class DownloadHandler(ABC):
         """
         wd = tempfile.mkdtemp()
         filename = None
+        extension = None
 
         # If the content type is generic and, therefore, cannot be used for determining
         # the file type, extract the file extension from the url, instead.


### PR DESCRIPTION
Fixes a bug left behind after #318

CAPEC: `CveXplore.core.database_maintenance.sources_process - ERROR    - Exception encountered during the download from: https://capec.mitre.org/data/xml/capec_latest.xml. Error encountered: local variable 'extension' referenced before assignment`

VIA4: `CveXplore.core.database_maintenance.sources_process - ERROR    - Exception encountered during the download from: https://www.cve-search.org/feeds/via4.json. Error encountered: local variable 'extension' referenced before assignment`