### PR TITLE
Populate vulnerable_configuration by cpes even if vulnerable: false

### DIFF
--- a/CveXplore/core/database_maintenance/sources_process.py
+++ b/CveXplore/core/database_maintenance/sources_process.py
@@ -843,51 +843,52 @@ class CVEDownloads(NVDApiHandler):
                         for cpeuri in cpe["cpeMatch"]:
                             if "criteria" not in cpeuri:
                                 continue
+                            cpe_info = None
+                            query = self.get_cpe_info(cpeuri)
+                            if query != {}:
+                                cpe_info = sorted(
+                                    self.getCPEVersionInformation(query),
+                                    key=lambda x: x["padded_version"],
+                                )
+                                if cpe_info:
+                                    if not isinstance(cpe_info, list):
+                                        cpe_info = [cpe_info]
                             if cpeuri["vulnerable"]:
-                                query = self.get_cpe_info(cpeuri)
-                                if query != {}:
-                                    cpe_info = sorted(
-                                        self.getCPEVersionInformation(query),
-                                        key=lambda x: x["padded_version"],
-                                    )
-                                    if cpe_info:
-                                        if not isinstance(cpe_info, list):
-                                            cpe_info = [cpe_info]
+                                if cpe_info:
+                                    for vulnerable_version in cpe_info:
+                                        cve = self.add_if_missing(
+                                            cve,
+                                            "vulnerable_product",
+                                            vulnerable_version["cpeName"],
+                                        )
+                                        cve = self.add_if_missing(
+                                            cve,
+                                            "vulnerable_configuration",
+                                            vulnerable_version["cpeName"],
+                                        )
+                                        cve = self.add_if_missing(
+                                            cve,
+                                            "vulnerable_configuration_stems",
+                                            vulnerable_version["stem"],
+                                        )
 
-                                        for vulnerable_version in cpe_info:
-                                            cve = self.add_if_missing(
-                                                cve,
-                                                "vulnerable_product",
-                                                vulnerable_version["cpeName"],
-                                            )
-                                            cve = self.add_if_missing(
-                                                cve,
-                                                "vulnerable_configuration",
-                                                vulnerable_version["cpeName"],
-                                            )
-                                            cve = self.add_if_missing(
-                                                cve,
-                                                "vulnerable_configuration_stems",
-                                                vulnerable_version["stem"],
-                                            )
+                                        cve = self.add_if_missing(
+                                            cve,
+                                            "vendors",
+                                            vulnerable_version["vendor"],
+                                        )
 
-                                            cve = self.add_if_missing(
-                                                cve,
-                                                "vendors",
-                                                vulnerable_version["vendor"],
-                                            )
+                                        cve = self.add_if_missing(
+                                            cve,
+                                            "products",
+                                            vulnerable_version["product"],
+                                        )
 
-                                            cve = self.add_if_missing(
-                                                cve,
-                                                "products",
-                                                vulnerable_version["product"],
-                                            )
-
-                                            cve = self.add_if_missing(
-                                                cve,
-                                                "vulnerable_product_stems",
-                                                vulnerable_version["stem"],
-                                            )
+                                        cve = self.add_if_missing(
+                                            cve,
+                                            "vulnerable_product_stems",
+                                            vulnerable_version["stem"],
+                                        )
                                 else:
                                     # If the cpeMatch did not have any of the version start/end modifiers,
                                     # add the CPE string as it is.
@@ -913,6 +914,18 @@ class CVEDownloads(NVDApiHandler):
                                         cve,
                                         "vulnerable_product_stems",
                                         self.stem(cpeuri["criteria"]),
+                                    )
+                            elif cpe_info:
+                                for vulnerable_version in cpe_info:
+                                    cve = self.add_if_missing(
+                                        cve,
+                                        "vulnerable_configuration",
+                                        vulnerable_version["cpeName"],
+                                    )
+                                    cve = self.add_if_missing(
+                                        cve,
+                                        "vulnerable_product_stems",
+                                        vulnerable_version["stem"],
                                     )
                             else:
                                 cve = self.add_if_missing(


### PR DESCRIPTION
Hello!

This PR extends the logic of point 1 from [Additional analysis during populating CPEs in CVE](https://github.com/cve-search/CveXplore/pull/323). Similarly, while testing and comparing results from NIST and the database populated by CveExplore, I encountered the following case:
For example, when searching for ```cpe:2.3:a:apache:http_server:2.4.29```, NIST finds 16 more CVEs than cve-search:
(CVE-2007-4723, CVE-2009-0796, CVE-2009-2299, CVE-2011-1176, CVE-2011-2688, CVE-2012-3526, CVE-2012-4001, CVE-2012-4360, CVE-2013-0941, CVE-2013-0942, CVE-2013-2765, CVE-2013-4365, CVE-2021-32785, CVE-2021-32786, CVE-2021-32791, CVE-2021-32792).
Example response from [NIST API for CVE-2013-4365](https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2013-4365):
```
{
  "operator": "AND",
  "nodes": [
    {
      "operator": "OR",
      "negate": false,
      "cpeMatch": [
        {
          "vulnerable": true,
          "criteria": "cpe:2.3:a:apache:mod_fcgid:*:*:*:*:*:*:*:*",
          "versionEndExcluding": "2.3.9",
          "matchCriteriaId": "E694842F-0EAC-4F02-BBFC-07D137FAF9F8"
        }
      ]
    },
    {
      "operator": "OR",
      "negate": false,
      "cpeMatch": [
        {
          "vulnerable": false,
          "criteria": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
          "matchCriteriaId": "5A6CD1F4-4C0E-4989-A2B3-DC086E8E80A3"
        }
      ]
    }
  ]
}

```
In this case, for ```apache:http_server```, the ```vulnerable``` key is set to ```false```. This condition does not pass the ```if cpeuri["vulnerable"]``` check in the ```process_the_item``` method of the ```CVEDownloads``` class.

If we incorporate the logic from point 1 of the previous PR into this PR, we can add references to these CPEs in ```vulnerable_configuration``` without cluttering ```vulnerable_product```.

Is my understanding of the ```vulnerable_configuration``` field correct? In this case, a user would be able to determine whether their software is part of a vulnerable configuration. Alternatively, they could search by ```vulnerable_products``` to find only those CVEs that are explicitly marked as affecting their software.

After applying these changes along with the previous PR, the results of the local database and NIST became identical when searching via ```vulnerable_configuration```.