### PR TITLE
Bump schema version after adding CVSSv4

### DIFF
--- a/CveXplore/.schema_version
+++ b/CveXplore/.schema_version
@@ -1,4 +1,4 @@
 {
-    "version": "1.9",
+    "version": "1.10",
     "rebuild_needed": true
 }


### PR DESCRIPTION
We forgot to bump the schema version after adding CVSSv4; users are not getting warnings that they need to repopulate the database.

Fixes https://github.com/cve-search/cve-search/issues/1143
