### PR TITLE
Update EPSS URL

### DIFF
--- a/CveXplore/common/config.py
+++ b/CveXplore/common/config.py
@@ -108,7 +108,7 @@ class Configuration(object):
         "cwe": "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip",
         "capec": "https://capec.mitre.org/data/xml/capec_latest.xml",
         "via4": "https://www.cve-search.org/feeds/via4.json",
-        "epss": "https://epss.cyentia.com/epss_scores-current.csv.gz",  # See EPSS at https://www.first.org/epss
+        "epss": "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz",  # See EPSS at https://www.first.org/epss
     }
 
     if os.getenv("SOURCES") is not None:


### PR DESCRIPTION
The `epss.cyentia.com` redirects to `epss.empiricalsecurity.com`; we might as well use it directly in the default configuration.

```
$ curl https://epss.cyentia.com/epss_scores-current.csv.gz -v
. . .
> GET /epss_scores-current.csv.gz HTTP/2
> Host: epss.cyentia.com
> user-agent: curl/7.81.0
> accept: */*
> 
. . .
< HTTP/2 301 
< content-length: 0
< location: https://epss.empiricalsecurity.com/epss_scores-current.csv.gz
. . .
```

The same update has been also suggested to CVE-Search in https://github.com/cve-search/cve-search/pull/1153