### PR TITLE
ci: replace outdated Bandit GitHub Action with direct installation

### DIFF
--- a/.github/workflows/bandit-sec-checks.yaml
+++ b/.github/workflows/bandit-sec-checks.yaml
@@ -5,7 +5,7 @@ on:
   - pull_request
 
 jobs:
-  build:
+  bandit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -14,18 +14,27 @@ jobs:
     name: Python ${{ matrix.python-version }} ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-    - name: Security check - Bandit
-      uses: Joel-hanson/bandit-report-artifacts@V1
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python_version: ${{ matrix.python-version }}
-        project_path: .
-        ignore_failure: true
+        python-version: ${{ matrix.python-version }}
 
-    - name: Security check report artifacts
-      uses: actions/upload-artifact@v4.6.0
-      # if: failure()
+    - name: Install Bandit
+      run: |
+        python -m pip install --upgrade pip
+        pip install bandit
+
+    - name: Run Bandit security scan
+      run: |
+        mkdir -p output
+        bandit -r . -f txt -o output/security_report.txt || true
+        echo "::warning::This workflow does not fail even if Bandit finds security issues."
+
+    - name: Upload Bandit report
+      uses: actions/upload-artifact@v4
       with:
-        name: secreport-${{ matrix.os }}-${{ matrix.python-version }}
+        name: security-report-${{ matrix.python-version }}
         path: output/security_report.txt


### PR DESCRIPTION
- Remove `Joel-hanson/bandit-report-artifacts@V1`, which uses an archived Debian repository and is no longer maintained.
- Install Bandit directly in the workflow for Python 3.10 and 3.11.
- Run Bandit recursively on the repository, always generating a report as an artifact for manual review (`output/security_report.txt`).
- Workflow does not fail on security findings; adds warning to logs to prevent a false sense of security.

Resolves https://github.com/cve-search/CveXplore/issues/331