### PR TITLE
style: update formatting to comply with black 2026 stable style

### DIFF
--- a/CveXplore/alembic/versions/0dc1d3ca2560_combined_changes_since_init.py
+++ b/CveXplore/alembic/versions/0dc1d3ca2560_combined_changes_since_init.py
@@ -11,7 +11,6 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision: str = "0dc1d3ca2560"
 down_revision: Union[str, None] = "ecb1788b7e08"

--- a/CveXplore/alembic/versions/8565fc904781_remove_mgmt_whitelist_blacklist.py
+++ b/CveXplore/alembic/versions/8565fc904781_remove_mgmt_whitelist_blacklist.py
@@ -11,7 +11,6 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision: str = "8565fc904781"
 down_revision: Union[str, None] = "0dc1d3ca2560"


### PR DESCRIPTION
This PR contains no functional changes. It applies formatting adjustments from the **2026 stable style** introduced in Black 26.1.0. The the GitHub workflow `psf/black@stable` has updated to [26.1.0](https://github.com/psf/black/releases/tag/26.1.0) (January) and is currently at [26.3.0](https://github.com/psf/black/releases/tag/26.3.0). See Black release notes for details.

### Changes

1. Normalize whitespace after imports
   - Collapse multiple blank lines after import statements to a single blank line
   - Aligns with 2026 stable style whitespace normalization:
     > `always_one_newline_after_import`: Always force one blank line after import
     > statements, except when the line after the import is a comment or an import statement