### PR TITLE
feat(config): add support for datasource URI query parameters (DATASOURCE_PARAMETERS)

### DIFF
--- a/CveXplore/common/config.py
+++ b/CveXplore/common/config.py
@@ -50,6 +50,50 @@ def getenv_dict(name: str, default: dict = None):
     return default
 
 
+def validate_datasource_parameters(value: str):
+    """
+    Validate DATASOURCE_PARAMETERS environment variable.
+
+    Ensures the value is a valid URI query string fragment used for
+    database connection configuration (e.g. authSource=cvedb).
+
+    Raises ValueError if invalid.
+    """
+    if not value:
+        return value
+
+    if value.startswith("?"):
+        raise ValueError(
+            "Invalid DATASOURCE_PARAMETERS: must not start with '?'. "
+            "Expected format: key=value&key=value"
+        )
+
+    pairs = value.split("&")
+
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(
+                "Invalid DATASOURCE_PARAMETERS: each entry must be in key=value format "
+                "(e.g. authSource=cvedb)"
+            )
+
+        key, val = pair.split("=", 1)
+
+        if not key:
+            raise ValueError(
+                "Invalid DATASOURCE_PARAMETERS: empty key detected "
+                "(expected key=value, e.g. authSource=cvedb)"
+            )
+
+        if not val:
+            raise ValueError(
+                f"Invalid DATASOURCE_PARAMETERS: '{key}' must have a value "
+                "(expected key=value, e.g. authSource=cvedb)"
+            )
+
+    return value
+
+
 class Configuration(object):
     """
     Class holding the configuration
@@ -84,7 +128,9 @@ class Configuration(object):
         quote_plus(DATASOURCE_PASSWORD) if DATASOURCE_PASSWORD else None
     )
     DATASOURCE_DBNAME = os.getenv("DATASOURCE_DBNAME", "cvedb")
-    DATASOURCE_PARAMETERS = os.getenv("DATASOURCE_PARAMETERS", None)
+    DATASOURCE_PARAMETERS = validate_datasource_parameters(
+        os.getenv("DATASOURCE_PARAMETERS", None)
+    )
 
     DATASOURCE_CONNECTION_DETAILS = None
 

--- a/CveXplore/common/config.py
+++ b/CveXplore/common/config.py
@@ -84,10 +84,11 @@ class Configuration(object):
         quote_plus(DATASOURCE_PASSWORD) if DATASOURCE_PASSWORD else None
     )
     DATASOURCE_DBNAME = os.getenv("DATASOURCE_DBNAME", "cvedb")
+    DATASOURCE_PARAMETERS = os.getenv("DATASOURCE_PARAMETERS", None)
 
     DATASOURCE_CONNECTION_DETAILS = None
 
-    DATASOURCE_HOST_URI = (
+    DATASOURCE_HOST_URI_BASE = (
         f"{DATASOURCE_PROTOCOL}"
         f"{'' if DATASOURCE_DBAPI is None else f'+{DATASOURCE_DBAPI}'}"
         f"://"
@@ -97,10 +98,22 @@ class Configuration(object):
         # must not be included here to avoid pymongo.errors.InvalidURI errors.
         f"{'' if DATASOURCE_DBAPI == 'srv' else f':{DATASOURCE_PORT}'}"
     )
+    DATASOURCE_HOST_URI_PARAMS = (
+        f"?{DATASOURCE_PARAMETERS}" if DATASOURCE_PARAMETERS else ""
+    )
+    # allows passing the host URI without database for a driver that takes it separately
+    DATASOURCE_HOST_URI = (
+        f"{DATASOURCE_HOST_URI_BASE}/{DATASOURCE_HOST_URI_PARAMS}"
+        if DATASOURCE_HOST_URI_PARAMS
+        else DATASOURCE_HOST_URI_BASE
+    )
 
     SQLALCHEMY_DATABASE_URI = os.getenv(
         "SQLALCHEMY_DATABASE_URI",
-        (f"{DATASOURCE_HOST_URI}/{DATASOURCE_DBNAME}"),
+        (
+            f"{DATASOURCE_HOST_URI_BASE}/{DATASOURCE_DBNAME}"
+            f"{DATASOURCE_HOST_URI_PARAMS}"
+        ),
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = getenv_bool(
         "SQLALCHEMY_TRACK_MODIFICATIONS", "False"

--- a/docs/database/settings.rst
+++ b/docs/database/settings.rst
@@ -39,6 +39,15 @@ Common
 
    Database name at the data source.
 
+.. confval:: DATASOURCE_PARAMETERS
+
+   Optional URI query string parameters appended to the constructed data source connection URI.
+
+   This value must be provided in ``key=value&key=value`` format (without a leading ``?``).
+
+   It is used to pass additional connection options to the underlying database driver.
+   See the database-specific documentation for supported parameters.
+
 .. confval:: DATASOURCE_CONNECTION_DETAILS
 
    *Not configurable via environment variables.*
@@ -63,6 +72,19 @@ MongoDB
 .. confval:: MONGODB_PORT
 
    MongoDB port number.
+
+.. confval:: DATASOURCE_PARAMETERS
+
+   Connection String Options (optional URI query string parameters) for the MongoDB data source.
+
+   Common options include ``authSource`` (authentication database),
+   ``replicaSet``, and ``retryWrites``.
+
+   Example:
+
+   ``authSource=cvedb&retryWrites=true``
+
+   See https://www.mongodb.com/docs/manual/reference/connection-string-options/
 
 .. confval:: MONGODB_CONNECTION_DETAILS
 


### PR DESCRIPTION
This change introduces support for passing URI query string parameters to datasource connection strings via the new `DATASOURCE_PARAMETERS` environment variable.

The feature allows configuring additional database driver options (e.g. MongoDB `authSource`, `replicaSet`, `retryWrites`) without modifying core connection logic or hardcoding driver-specific behavior.

## Motivation

CveXplore currently constructs datasource connection URIs from individual environment variables (host, port, credentials, etc.). However, some database drivers (notably MongoDB) require additional connection options that are only supported via URI query parameters.

This was identified through a downstream issue https://github.com/cve-search/cve-search/issues/1211, where authentication fails when the MongoDB authentication database (`authSource`) differs from the default `admin`.

## Changes

- Add `DATASOURCE_PARAMETERS` environment variable
- Append parameters to constructed datasource URI when provided
- Apply parameters consistently across MongoDB and SQLAlchemy URIs
- Add validation to ensure correct `key=value&key=value` format
- Reject malformed parameters early to avoid silent connection failures
- Add documentation for both generic and MongoDB-specific usage

## Validation

The value of `DATASOURCE_PARAMETERS` is validated to ensure:
- It follows `key=value&key=value` format
- It does not start with `?` (as it is added when constructing the URI)
- Each entry contains a valid key and value

Invalid values raise a `ValueError` at configuration time.

## Documentation

Documentation includes:
- Generic explanation of datasource URI parameters
- MongoDB-specific behavior and examples
- Reference to official MongoDB connection string options:
  https://www.mongodb.com/docs/manual/reference/connection-string-options/

## Impact

This change is backward compatible:
- No changes required for existing configurations
- Feature is opt-in via environment variable
- Existing URI construction remains unchanged unless parameters are provided

## Downstream impact

This resolves authentication configuration limitations in downstream projects using CveXplore as a library, where MongoDB requires custom authentication parameters that were previously not supported. No code changes are required in downstream projects as configuration is done via environment variables.